### PR TITLE
feat: Allow reading/writing FASTA files using arguments of type `str` or `Path`

### DIFF
--- a/src/iv2py/fasta.cpp
+++ b/src/iv2py/fasta.cpp
@@ -5,6 +5,7 @@
 
 #include <ivio/ivio.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl/filesystem.h>
 
 namespace py = pybind11;
 void init_fasta_mod(py::module& parent_mod) {
@@ -27,7 +28,7 @@ void init_fasta_mod(py::module& parent_mod) {
 
     // Providing the reader class
     py::class_<record_reader<ivio::fasta::reader>>(mod, "reader")
-        .def(py::init([](std::string const& path) {
+        .def(py::init([](std::filesystem::path const& path) {
             return std::make_unique<record_reader<ivio::fasta::reader>>(path);
         }), py::arg("file"))
         .def("__iter__", [](record_reader<ivio::fasta::reader>& r) {
@@ -37,7 +38,7 @@ void init_fasta_mod(py::module& parent_mod) {
 
     // Providing the writer class
     py::class_<ivio::fasta::writer>(mod, "writer")
-        .def(py::init([](std::string const& path) {
+        .def(py::init([](std::filesystem::path const& path) {
             return std::make_unique<ivio::fasta::writer>(ivio::fasta::writer::config{path});
         }), py::arg("file"))
         .def("write", [](ivio::fasta::writer& writer, ivio::fasta::record const& record) {

--- a/src/iv2py/record_reader.h
+++ b/src/iv2py/record_reader.h
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #pragma once
 
-#include <string>
+#include <filesystem>
 #include <ranges>
 
 template <typename reader>
 struct record_reader {
     reader reader_;
 
-    record_reader(std::string const& path)
+    record_reader(std::filesystem::path const& path)
         : reader_{{path}}
     {}
 


### PR DESCRIPTION
Allow passing arguments to read/write FASTA files either of type `str` or `Path`

fixes #18 