### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/ci_on_pr.yml
+++ b/.github/workflows/ci_on_pr.yml
@@ -46,7 +46,7 @@ jobs:
           cmake_cxx_flags: ${{ matrix.cmake_cxx_flags }}
       - uses: actions/setup-python@v5
         with:
-          python-version: 'pypy3.7'
+          python-version: 'pypy3.8'
       - name: Install package in Python with testing dependencies
         working-directory: ./repo
         run: pip install '.[test]'

--- a/.github/workflows/ci_on_pr.yml
+++ b/.github/workflows/ci_on_pr.yml
@@ -47,10 +47,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 'pypy3.7'
-      - name: Install in Python
+      - name: Install package in Python with testing dependencies
+        working-directory: ./repo
         run: pip install '.[test]'
-      - name: Test
-        run: pytest tests/
+      - name: Test in Python
+        run: pytest ./repo/tests/
   final:
     runs-on: ubuntu-22.04
     name: final-pass

--- a/.github/workflows/ci_on_pr.yml
+++ b/.github/workflows/ci_on_pr.yml
@@ -44,6 +44,13 @@ jobs:
           cmake_flags: ${{ matrix.cmake_flags }}
           cmake_c_flags: ${{ matrix.cmake_c_flags }}
           cmake_cxx_flags: ${{ matrix.cmake_cxx_flags }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 'pypy3.7'
+      - name: Install in Python
+        run: pip install '.[test]'
+      - name: Test
+        run: pytest tests/
   final:
     runs-on: ubuntu-22.04
     name: final-pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/iv-project/IV2py"
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [tool.cibuildwheel.linux]
 # Use manylinux_2_28 to have a gcc12 compiler
 manylinux-x86_64-image = "manylinux_2_28"

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Matthew Martin <matthew@mttmartin.com>
+# SPDX-License-Identifier: MIT
+
 import iv2py as iv
 
 def test_fasta_read(tmp_path):

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -1,0 +1,31 @@
+import iv2py as iv
+
+def test_fasta_read(tmp_path):
+    # Setup an example fasta file
+    records = {"1": "ATGATG", "2": "TTTTTT" }
+    fasta_path = tmp_path/"input.fa"
+    with open(fasta_path, "w") as f:
+        for record in records:
+            f.write(f">{record}\n")
+            f.write(records[record]+"\n")
+
+    for i, record in enumerate(iv.fasta.reader(file=fasta_path)):
+        assert record.seq == records[str(record.id)]
+        assert str(i+1) == record.id
+
+def test_fasta_write(tmp_path):
+    fasta_path = tmp_path/"output.fa"
+    record = iv.fasta.record(id="1", seq="ATG")
+
+    assert fasta_path.is_file() is False
+    writer = iv.fasta.writer(file=fasta_path)
+    writer.write(record)
+    writer.close()
+    assert fasta_path.is_file() is True
+
+    for record in iv.fasta.reader(file=fasta_path):
+        assert record.id == "1"
+        assert record.seq == "ATG"
+
+
+

--- a/tests/test_fmindex.py
+++ b/tests/test_fmindex.py
@@ -1,0 +1,32 @@
+import pytest
+
+import iv2py as iv
+
+
+@pytest.mark.parametrize("reference,pattern,expected", [(["AACCGGTT", "ACGT"], "CG", [(0, 3), (0, 10)])])
+def test_load(tmp_path, reference, pattern, expected):
+    index_path = tmp_path / "myindex.idx"
+    index = iv.fmindex(reference=reference, samplingRate=16)
+
+    # test that we are actually writing a file to the right place
+    assert index_path.is_file() is False
+    index.save(index_path)
+    assert index_path.is_file() is True
+
+    index_2 = iv.fmindex(index_path)
+
+    # if we can still get valid search results, the index should be okay
+    assert index_2.search(pattern) == expected 
+
+@pytest.mark.parametrize("reference,pattern,expected", [(["AACCGGTT", "ACGT"], "GGT", [(0, 5), (0, 10), (0, 4)])])
+def test_search_mismatches(reference, pattern, expected):
+    index = iv.fmindex(reference=reference, samplingRate=16)
+
+    assert index.search(pattern, k=1) == expected
+
+@pytest.mark.parametrize("reference,pattern,expected", [(["AACCGGTT", "ACGT"], "CG", [(0, 3), (0, 10)])])
+def test_search(reference, pattern, expected):
+    index = iv.fmindex(reference=reference, samplingRate=16)
+
+    assert index.search(pattern) == expected
+

--- a/tests/test_fmindex.py
+++ b/tests/test_fmindex.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Matthew Martin <matthew@mttmartin.com>
+# SPDX-License-Identifier: MIT
+
 import pytest
 
 import iv2py as iv

--- a/tests/test_suffixarray.py
+++ b/tests/test_suffixarray.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Matthew Martin <matthew@mttmartin.com>
+# SPDX-License-Identifier: MIT
+
 import iv2py as iv
 
 def test_suffixarray():

--- a/tests/test_suffixarray.py
+++ b/tests/test_suffixarray.py
@@ -1,0 +1,7 @@
+import iv2py as iv
+
+def test_suffixarray():
+    reference = "Hello world"
+    sa = iv.create_suffixarray("Hello world")
+    assert reference[sa[0]-1] == "o"
+    assert reference[sa[-1]-1] == " "


### PR DESCRIPTION
I added some simple tests of the Python parts with the exception of the BAM/SAM functionality. The tests are mainly just taken form the documentation, but should be enough to ensure things are mostly working.

Marking this as a draft, because I think the workflow might work as is, but haven't tested it. I imagine it will need to be integrated a bit with `iv-project/IVaction`, at least so everything is not being compiled twice (if it's not already cached somewhere as is so the pip install will not recompile). Do you see a good way to do this?